### PR TITLE
Refactored MusicSheet to discrete types via router

### DIFF
--- a/src/components/music/MusicSheet.js
+++ b/src/components/music/MusicSheet.js
@@ -1,0 +1,103 @@
+import React from "react"
+import withSimpleErrorBoundary from "../../util/withSimpleErrorBoundary"
+import Fab from "@material-ui/core/Fab"
+import PlayArrowIcon from "@material-ui/icons/PlayArrow"
+
+/**
+ * In charge of rendering Music Sheet notes and play button based on parameters passed to it.
+ *
+ * Use src/partials/MusicSheet when using MusicSheet inside other components
+ */
+class MusicSheet extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      render: false,
+      engraverParams: props.engraverParams
+        ? props.engraverParams
+        : {
+            add_classes: false,
+            editable: false,
+            listener: null,
+            paddingbottom: 30,
+            paddingleft: 15,
+            paddingright: 50,
+            paddingtop: 15,
+            responsive: undefined,
+            scale: 1,
+            staffwidth: 740,
+          },
+      id: "music-midi-" + Math.floor(Math.random() * 10000),
+      renderNotes: props.renderNotes ? true : false,
+      renderSound: props.renderSound ? true : false,
+      playbuttonstyle: props.playbuttonstyle
+        ? props.playbuttonstyle
+        : "playbutton",
+    }
+  }
+
+  componentDidMount() {
+    // react-abc can not be imported directly since it uses
+    // abcjs that is a non react library.
+    // abcjs attempts to use DOM api that is not available when
+    // gatsby runs build, so it's server side rendering had to be
+    // disabled.
+    // -> Dynamic import is used instead.
+    import("react-abc").then(react_abc => {
+      this.setState({ render: true, react_abc: react_abc })
+    })
+  }
+
+  render() {
+    if (!this.state.render) {
+      return <p>Loading..</p>
+    }
+
+    const renderNotes = this.state.renderNotes
+    const renderSound = this.state.renderSound
+    const notation = this.props.notation
+
+    return (
+      <>
+        {renderNotes && this.renderNotation(notation)}
+        {renderSound && this.renderPlayButton(notation)}
+      </>
+    )
+  }
+
+  renderNotation(notation) {
+    return (
+      <this.state.react_abc.Notation
+        notation={notation}
+        engraverParams={this.state.engraverParams}
+      />
+    )
+  }
+
+  renderPlayButton(notation) {
+    return (
+      <>
+        <div id={this.state.id}>
+          <this.state.react_abc.Midi notation={notation} />
+        </div>
+        <div className={this.state.playbuttonstyle}>
+          <Fab color="primary" onClick={() => this.onPlay()}>
+            <PlayArrowIcon />
+          </Fab>
+        </div>
+      </>
+    )
+  }
+
+  onPlay() {
+    const original = document
+      .querySelector("#" + this.state.id)
+      .querySelector(".abcjs-midi-start.abcjs-btn")
+    if (original) {
+      original.click()
+    }
+  }
+}
+
+export default withSimpleErrorBoundary(MusicSheet)

--- a/src/partials/MusicExercise.js
+++ b/src/partials/MusicExercise.js
@@ -1,8 +1,6 @@
 import React, { Fragment } from "react"
 import { Button, Icon } from "@material-ui/core"
-import LoginStateContext from "../contexes/LoginStateContext"
 import withSimpleErrorBoundary from "../util/withSimpleErrorBoundary"
-import Loading from "../components/Loading"
 
 import MusicSheet from "./MusicSheet"
 import CheckAnswerPopper from "./CheckAnswerPopper"
@@ -133,8 +131,8 @@ class MusicExercise extends React.Component {
           <div className="left-container">
             <MusicSheet
               notation={this.state.notation}
-              only_notes={this.props.onlyNotes}
-              only_sound={this.props.onlySound}
+              onlynotes={this.props.onlyNotes}
+              onlysound={this.props.onlySound}
               engraverParams={engraverParams}
             />
           </div>

--- a/src/partials/MusicSheet.js
+++ b/src/partials/MusicSheet.js
@@ -1,115 +1,101 @@
 import React from "react"
-import { Fragment } from "react"
-import withSimpleErrorBoundary from "../util/withSimpleErrorBoundary"
-import Fab from "@material-ui/core/Fab"
-import PlayArrowIcon from "@material-ui/icons/PlayArrow"
 
-class MusicSheet extends React.Component {
-  /*
-    props need to be all lowercase since this component is used
-    in the .md files
+import MusicSheet from "../components/music/MusicSheet"
 
-    props: {
-      notation: String, abc format music notation
-      only_notes: Boolean
-      only_sound: Boolean
-    }
-  */
-  constructor(props) {
-    super(props)
+/**
+ * In charge of routing <music-sheet> partial to components
+ */
+const MusicSheetRouter = ({ onlynotes, onlysound, ...other }) => {
+  const onlyNotes = onlynotes // partials only allow lowercase props
+  const onlySound = onlysound // partials only allow lowercase props
 
-    this.state = {
-      render: false,
-      engraverParams: props.engraverParams
-        ? props.engraverParams
-        : {
-            add_classes: false,
-            editable: false,
-            listener: null,
-            paddingbottom: 30,
-            paddingleft: 15,
-            paddingright: 50,
-            paddingtop: 15,
-            responsive: undefined,
-            scale: 1,
-            staffwidth: 740,
-          },
-      id: "music-midi-" + Math.floor(Math.random() * 10000),
-      onlyNotes: props.only_notes ? true : false,
-      onlySound: props.only_sound ? true : false,
-      playbuttonstyle: props.playbuttonstyle
-        ? props.playbuttonstyle
-        : "playbutton",
-    }
-  }
-
-  componentDidMount() {
-    // react-abc can not be imported directly since it uses
-    // abcjs that is a non react library.
-    // abcjs attempts to use DOM api that is not available when
-    // gatsby runs build, so it's server side rendering had to be
-    // disabled.
-    // -> Dynamic import is used instead.
-    import("react-abc").then(react_abc => {
-      this.setState({ render: true, react_abc: react_abc })
-    })
-  }
-
-  render() {
-    if (!this.state.render) {
-      return <p>Loading..</p>
-    }
-
-    const onlyNotes = this.state.onlyNotes
-    const onlySound = this.state.onlySound
-    const notation = this.props.notation
-
-    if ((onlySound && onlyNotes) || (!onlySound && !onlyNotes)) {
-      return (
-        <>
-          {this.renderNotation(notation)}
-          {this.renderPlayButton(notation)}
-        </>
-      )
-    } else if (onlyNotes) {
-      return this.renderNotation(notation)
-    } else if (onlySound) {
-      return this.renderPlayButton(notation)
-    }
-  }
-
-  renderNotation(notation) {
-    return (
-      <this.state.react_abc.Notation
-        notation={notation}
-        engraverParams={this.state.engraverParams}
-      />
-    )
-  }
-
-  renderPlayButton(notation) {
-    return (
-      <>
-        <div id={this.state.id}>
-          <this.state.react_abc.Midi notation={notation} />
-        </div>
-        <div className={this.state.playbuttonstyle}>
-          <Fab color="primary" onClick={() => this.onPlay()}>
-            <PlayArrowIcon />
-          </Fab>
-        </div>
-      </>
-    )
-  }
-
-  onPlay() {
-    const original = document
-      .querySelector("#" + this.state.id)
-      .querySelector(".abcjs-midi-start.abcjs-btn")
-    if (original) {
-      original.click()
-    }
+  if ((onlySound && onlyNotes) || (!onlySound && !onlyNotes)) {
+    // If both are true or both are false, render both notes and sound
+    return <NotesAndSoundMusicSheet {...other} />
+  } else if (onlyNotes) {
+    return <NotesMusicSheet {...other} />
+  } else if (onlySound) {
+    return <SoundMusicSheet {...other} />
   }
 }
 
-export default withSimpleErrorBoundary(MusicSheet)
+/**
+ * Renders both notes and play button
+ */
+const NotesAndSoundMusicSheet = ({
+  engraverParams,
+  playButtonStyle,
+  ...other
+}) => {
+  return (
+    <MusicSheet
+      {...other}
+      renderNotes={true}
+      renderSound={true}
+      engraverParams={
+        engraverParams
+          ? engraverParams
+          : {
+              // default engraverParams
+              add_classes: false,
+              editable: false,
+              listener: null,
+              paddingbottom: 30,
+              paddingleft: 15,
+              paddingright: 50,
+              paddingtop: 15,
+              responsive: undefined,
+              scale: 1,
+              staffwidth: 740,
+            }
+      }
+      playButtonStyle={playButtonStyle ? playButtonStyle : "playbutton"} // default playButtonStyle
+    />
+  )
+}
+
+/**
+ * Renders notes
+ */
+const NotesMusicSheet = ({ engraverParams, ...other }) => {
+  return (
+    <MusicSheet
+      {...other}
+      renderNotes={true}
+      renderSound={false}
+      engraverParams={
+        engraverParams
+          ? engraverParams
+          : {
+              // default engraverParams
+              add_classes: false,
+              editable: false,
+              listener: null,
+              paddingbottom: 30,
+              paddingleft: 15,
+              paddingright: 50,
+              paddingtop: 15,
+              responsive: undefined,
+              scale: 1,
+              staffwidth: 740,
+            }
+      }
+    />
+  )
+}
+
+/**
+ * Renders play button
+ */
+const SoundMusicSheet = ({ playButtonStyle, ...other }) => {
+  return (
+    <MusicSheet
+      {...other}
+      renderNotes={false}
+      renderSound={true}
+      playButtonStyle={playButtonStyle ? playButtonStyle : "playbutton"} // default playButtonStyle
+    />
+  )
+}
+
+export default MusicSheetRouter


### PR DESCRIPTION
MusicSheet was getting tons of engraverParams based on what kind of sheet was going to be rendered (Both / Notes / Play button) - This is part 1 of a refactoring to make these parameters configurable per type.

## Changes in this commit:

### `/partials/MusicSheet` now includes 4 components:
  - MusicSheetRouter (exported default)
  - NotesAndSoundMusicSheet
  - NotesMusicSheet
  - SoundMusicSheet

Older component from `partials/MusicSheet` was moved to `/components/music/MusicSheet`

#### MusicSheetRouter

- Takes in props from users (eg. `<music-sheet onlynotes=true>` and renders other components accordingly (`NotesMusicSheet` in this example)

#### NotesAndSoundMusicSheet

- Gives props to `/components/music/MusicSheet` for rendering both notes and sound

#### NotesMusicSheet

- Gives props to `/components/music/MusicSheet` for rendering notes

#### SoundMusicSheet

- Gives props to `/components/music/MusicSheet` for rendering play button