### PR TITLE
Fix bug causing that new notation is not played

### DIFF
--- a/src/components/music/MusicSheet.js
+++ b/src/components/music/MusicSheet.js
@@ -50,6 +50,20 @@ class MusicSheet extends React.Component {
     })
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.notation !== prevProps.notation) {
+      this.setState({
+        react_abc: null,
+        render: false,
+      })
+    }
+    if (!this.state.render) {
+      import("react-abc").then(react_abc => {
+        this.setState({ render: true, react_abc: react_abc })
+      })
+    }
+  }
+
   render() {
     if (!this.state.render) {
       return <p>Loading..</p>


### PR DESCRIPTION
React_abc component is imported again each time when exercise is changed and new notation comes as props into src/components/music/MusicSheet.js component.