### PR TITLE
Added support for compound intervals (8 -> 14)

### DIFF
--- a/src/util/__tests__/musicUtils.test.js
+++ b/src/util/__tests__/musicUtils.test.js
@@ -7,41 +7,77 @@ import { interval, roots, triads } from "../musicUtils"
 */
 
 describe("interval()", () => {
+  it("returns D sharp as E's major seventh", () => {
+    const e = roots[6]
+    expect(interval(e, "maj", 7)).toBe("^d")
+  })
   it("returns E flat as F sharp's diminished seventh", () => {
     const fSharp = roots[8]
     expect(interval(fSharp, "dim", 7)).toBe("_e")
   })
-  it("returns B double flat as E flat's diminished fifth", () => {
-    const eFlat = roots[5]
-    expect(interval(eFlat, "dim", 5)).toBe("__B")
-  })
-  it("returns D sharp as A's augmented fourth", () => {
-    const a = roots[13]
-    expect(interval(a, "aug", 4)).toBe("^d")
-  })
-  it("returns D sharp as E's major seventh", () => {
-    const e = roots[6]
-    expect(interval(e, "maj", 7)).toBe("^d")
+  it("returns F flat as G flat's minor fourteenth", () => {
+    const gFlat = roots[9]
+    expect(interval(gFlat, "min", 14)).toBe("_f'")
   })
   it("returns F sharp as A sharp's minor sixth", () => {
     const aSharp = roots[14]
     expect(interval(aSharp, "min", 6)).toBe("^f")
   })
+  it("returns C flat as E's diminished thirteenth", () => {
+    const e = roots[6]
+    expect(interval(e, "dim", 13)).toBe("_c'")
+  })
+  it("returns B double flat as E flat's diminished fifth", () => {
+    const eFlat = roots[5]
+    expect(interval(eFlat, "dim", 5)).toBe("__B")
+  })
+  it("returns C as F sharp's diminished twelfth", () => {
+    const fSharp = roots[8]
+    expect(interval(fSharp, "dim", 12)).toBe("c'")
+  })
+  it("returns G as C's perfect twelfth", () => {
+    const c = roots[0]
+    expect(interval(c, "perf", 12)).toBe("g")
+  })
+  it("returns D sharp as A's augmented fourth", () => {
+    const a = roots[13]
+    expect(interval(a, "aug", 4)).toBe("^d")
+  })
+  it("returns C flat as G's diminished eleventh", () => {
+    const g = roots[10]
+    expect(interval(g, "dim", 11)).toBe("_c'")
+  })
   it("returns F flat as D flat's minor third", () => {
     const dFlat = roots[2]
     expect(interval(dFlat, "min", 3)).toBe("_F")
+  })
+  it("returns G as E flat's major tenth", () => {
+    const eFlat = roots[5]
+    expect(interval(eFlat, "maj", 10)).toBe("g")
   })
   it("returns A double sharp as G sharp's augmented second", () => {
     const gSharp = roots[11]
     expect(interval(gSharp, "aug", 2)).toBe("^^A")
   })
-  it("returns A as G's major second", () => {
+  it("returns A flat as G's minor second", () => {
     const g = roots[10]
-    expect(interval(g, "maj", 2)).toBe("A")
+    expect(interval(g, "min", 2)).toBe("_A")
+  })
+  it("returns C as B flat's major ninth", () => {
+    const bFlat = roots[15]
+    expect(interval(bFlat, "maj", 9)).toBe("c'")
   })
   it("returns D as D's unison", () => {
     const d = roots[3]
     expect(interval(d, "perf", 1)).toBe("D")
+  })
+  it("returns B sharp as B's augmented octave", () => {
+    const b = roots[16]
+    expect(interval(b, "aug", 8)).toBe("^b")
+  })
+  it("returns E flat as E's diminished octave", () => {
+    const e = roots[6]
+    expect(interval(e, "dim", 8)).toBe("_e")
   })
 })
 


### PR DESCRIPTION
The octave interval was needed for the interval exercise.
Adding support also for intervals up to 14th required
approximately the same amount of work, and it's better
for future developments (it's likely that those intervals
will be needed). This was achieved by creating a raiseOctave()
function, which raises its input abc notation up an octave.
All the functionality of raiseOctave wasn't immediately
needed, but since it required only a small amount of additional
work it was done like this, so that it can be useful also for
other possible future developments. With raiseOctave(), interval()
required only changes in a couple of rows.

Automated tests have been written for this new functionality.