### PR TITLE
Fix reversed scale bug

### DIFF
--- a/src/util/__tests__/musicUtils.test.js
+++ b/src/util/__tests__/musicUtils.test.js
@@ -124,6 +124,13 @@ describe("Scale.notation()", () => {
     const majorScale = scales[0]
     expect(majorScale.notation(aFlat)).toBe("L:1/4\n_A_Bc_d_efg_agf_e_dc_B_A")
   })
+  it("returns correct A sharp major scale", () => {
+    const aSharp = roots[14]
+    const majorScale = scales[0]
+    expect(majorScale.notation(aSharp)).toBe(
+      "L:1/4\n^A^B^^c^d^e^^f^^g^a^^g^^f^e^d^^c^B^A",
+    )
+  })
   it("returns correct F sharp natural minor scale", () => {
     const fSharp = roots[8]
     const naturalMinorScale = scales[1]
@@ -141,6 +148,20 @@ describe("Scale.notation()", () => {
     const melodicMinorScale = scales[3]
     expect(melodicMinorScale.notation(dSharp)).toBe(
       "L:1/4\n^D^E^F^G^A^B^^c^d^cB^A^G^F^E^D",
+    )
+  })
+  it("returns correct A flat melodic minor scale", () => {
+    const aSharp = roots[14]
+    const melodicMinorScale = scales[3]
+    expect(melodicMinorScale.notation(aSharp)).toBe(
+      "L:1/4\n^A^B^c^d^e^^f^^g^a^g^f^e^d^c^B^A",
+    )
+  })
+  it("returns correct A sharp melodic minor scale", () => {
+    const aFlat = roots[12]
+    const melodicMinorScale = scales[3]
+    expect(melodicMinorScale.notation(aFlat)).toBe(
+      "L:1/4\n_A_B_c_d_efg_a_g_f_e_d_c_B_A",
     )
   })
 
@@ -173,7 +194,7 @@ describe("Scale.notation()", () => {
       "L:1/4\n^G^A^B^c^d^e^f^g^f^e^d^c^B^A^G",
     )
   })
-  it("returns correct E flat Aeolian  mode", () => {
+  it("returns correct E flat Aeolian mode", () => {
     const eFlat = roots[5]
     const aeolianMode = modes[5]
     expect(aeolianMode.notation(eFlat)).toBe(

--- a/src/util/music/scales.js
+++ b/src/util/music/scales.js
@@ -40,7 +40,7 @@ class Scale {
       concatenate(
         root,
         this.symmetric
-          ? this.intervals.reverse()
+          ? this.intervals.slice().reverse()
           : this.intervals.slice(this.intervals.length / 2),
       ) +
       root.notation


### PR DESCRIPTION
Scale.notation() used Array.prototype.reverse() method, which
reverts the array in place; when the same scale from scales
was generated a second time, it was generated from the reverted
array. Now reverse() is applied to a copy of the original array.