### PR TITLE
Moved piano sound loading to MidiSoundContext

### DIFF
--- a/src/contexes/MidiSoundContext.js
+++ b/src/contexes/MidiSoundContext.js
@@ -1,0 +1,60 @@
+import React from "react"
+
+export const MidiSoundContext = React.createContext()
+
+export class MidiSoundContextProvider extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {}
+  }
+
+  componentDidMount() {
+    if (!this.state.react_abc) {
+      import("react-abc").then(react_abc => {
+        this.setState({ render: true, react_abc })
+      })
+    }
+  }
+
+  componentDidUpdate() {
+    if (this.state.render && !this.state.soundLoaded) {
+      this.loadPianoSound()
+    }
+  }
+
+  loadPianoSound() {
+    const div = document.querySelector("#empty-abcjs-midi")
+    if (!div) {
+      return
+    }
+    const original = div.querySelector(".abcjs-midi-start.abcjs-btn")
+    if (original) {
+      original.click()
+      // Wait one second for the piano sound to load
+      // The sound doesn't fire for some reason, even with voicesOff
+      setTimeout(() => this.setState({ soundLoaded: true }), 1000)
+    }
+  }
+
+  renderEmptyMidi() {
+    return (
+      <div id="empty-abcjs-midi" style={{ display: "none" }}>
+        <this.state.react_abc.Midi
+          midiParams={{ voicesOff: true }}
+          notation="L:1/1\n[]"
+        />
+      </div>
+    )
+  }
+
+  render() {
+    return (
+      <MidiSoundContext.Provider
+        value={{ soundLoaded: this.state.soundLoaded }}
+      >
+        {this.state.render && this.renderEmptyMidi()}
+        {this.props.children}
+      </MidiSoundContext.Provider>
+    )
+  }
+}

--- a/src/templates/CourseContentTemplate.js
+++ b/src/templates/CourseContentTemplate.js
@@ -15,6 +15,7 @@ import PagesContext from "../contexes/PagesContext"
 import LoginStateContext, {
   LoginStateContextProvider,
 } from "../contexes/LoginStateContext"
+import { MidiSoundContextProvider } from "../contexes/MidiSoundContext"
 import Container from "../components/Container"
 
 import { loggedIn } from "../services/moocfi"
@@ -92,22 +93,24 @@ export default class CourseContentTemplate extends React.Component {
         <Helmet title={frontmatter.title} />
         <PagesContext.Provider value={{ all: allPages, current: frontmatter }}>
           <LoginStateContextProvider>
-            <Layout>
-              <Fragment>
-                <Container>
-                  <ContentWrapper>
-                    <UpLink to={parentSectionPath}>
-                      <StyledIcon icon={icon} />
-                      {parentSectionName}
-                    </UpLink>
-                    <h1>{frontmatter.title}</h1>
-                    {renderAst(htmlAst)}
-                    <EndOfSubSection />
-                  </ContentWrapper>
-                </Container>
-                <CoursePageFooter />
-              </Fragment>
-            </Layout>
+            <MidiSoundContextProvider>
+              <Layout>
+                <Fragment>
+                  <Container>
+                    <ContentWrapper>
+                      <UpLink to={parentSectionPath}>
+                        <StyledIcon icon={icon} />
+                        {parentSectionName}
+                      </UpLink>
+                      <h1>{frontmatter.title}</h1>
+                      {renderAst(htmlAst)}
+                      <EndOfSubSection />
+                    </ContentWrapper>
+                  </Container>
+                  <CoursePageFooter />
+                </Fragment>
+              </Layout>
+            </MidiSoundContextProvider>
           </LoginStateContextProvider>
         </PagesContext.Provider>
       </Fragment>

--- a/src/templates/CoursePartOverviewTemplate.js
+++ b/src/templates/CoursePartOverviewTemplate.js
@@ -14,6 +14,7 @@ import PagesContext from "../contexes/PagesContext"
 import LoginStateContext, {
   LoginStateContextProvider,
 } from "../contexes/LoginStateContext"
+import { MidiSoundContextProvider } from "../contexes/MidiSoundContext"
 import Container from "../components/Container"
 
 import { loggedIn } from "../services/moocfi"
@@ -66,16 +67,18 @@ export default class CoursePartOverviewTemplate extends React.Component {
       >
         <Helmet title={frontmatter.title} />
         <LoginStateContextProvider>
-          <Layout>
-            <Fragment>
-              <Container>
-                <ContentWrapper>
-                  <Title>{frontmatter.title}</Title>
-                  {renderAst(htmlAst)}
-                </ContentWrapper>
-              </Container>
-            </Fragment>
-          </Layout>
+          <MidiSoundContextProvider>
+            <Layout>
+              <Fragment>
+                <Container>
+                  <ContentWrapper>
+                    <Title>{frontmatter.title}</Title>
+                    {renderAst(htmlAst)}
+                  </ContentWrapper>
+                </Container>
+              </Fragment>
+            </Layout>
+          </MidiSoundContextProvider>
         </LoginStateContextProvider>
       </PagesContext.Provider>
     )

--- a/src/templates/InfoPageTemplate.js
+++ b/src/templates/InfoPageTemplate.js
@@ -10,6 +10,7 @@ import getNamedPartials from "../partials"
 
 import "./remark.css"
 import { LoginStateContextProvider } from "../contexes/LoginStateContext"
+import { MidiSoundContextProvider } from "../contexes/MidiSoundContext"
 import Banner from "../components/Banner"
 import Container from "../components/Container"
 
@@ -29,17 +30,19 @@ export default class InfoPageTemplate extends React.Component {
       <Fragment>
         <Helmet title={frontmatter.title} />
         <LoginStateContextProvider>
-          <Layout>
-            <Fragment>
-              {frontmatter.banner && <Banner />}
-              <Container>
-                <ContentWrapper>
-                  <h1>{frontmatter.title}</h1>
-                  {renderAst(htmlAst)}
-                </ContentWrapper>
-              </Container>
-            </Fragment>
-          </Layout>
+          <MidiSoundContextProvider>
+            <Layout>
+              <Fragment>
+                {frontmatter.banner && <Banner />}
+                <Container>
+                  <ContentWrapper>
+                    <h1>{frontmatter.title}</h1>
+                    {renderAst(htmlAst)}
+                  </ContentWrapper>
+                </Container>
+              </Fragment>
+            </Layout>
+          </MidiSoundContextProvider>
         </LoginStateContextProvider>
       </Fragment>
     )


### PR DESCRIPTION
Empty sound is now played only once per page when the page loads, to load the piano sound.

one second delay was added to wait for the piano sound to be loaded.
This could be made more accurate with `midiListener` for abcjs, but the sound doesn't fire when the play button is pressed on the empty sound.