### PR TITLE
Fix augmented unison notation bug

### DIFF
--- a/src/util/music/chords.js
+++ b/src/util/music/chords.js
@@ -1,6 +1,6 @@
 import { DIMINISHED, MINOR, MAJOR, PERFECT, AUGMENTED } from "./qualities"
 import {
-  interval,
+  concatenate,
   UNISON,
   SECOND,
   THIRD,
@@ -20,16 +20,15 @@ class Chord {
   notation(root) {
     return (
       "L:1/1\n[" +
-      root.notation +
-      this.intervals.map(i => interval(root, ...i)).join("") +
+      concatenate(root, [[PERFECT, UNISON], ...this.intervals]) +
       "]"
     )
   }
 }
 
 export const triads = [
-  new Chord("Duuri", [[MAJOR, THIRD], [PERFECT, FIFTH]]),
-  new Chord("Molli", [[MINOR, THIRD], [PERFECT, FIFTH]]),
+  new Chord("Duuri", [[PERFECT, UNISON], [MAJOR, THIRD], [PERFECT, FIFTH]]),
+  new Chord("Molli", [[PERFECT, UNISON], [MINOR, THIRD], [PERFECT, FIFTH]]),
   new Chord("Vähennetty", [[MINOR, THIRD], [DIMINISHED, FIFTH]]),
   new Chord("Ylinouseva", [[MAJOR, THIRD], [AUGMENTED, FIFTH]]),
 ]

--- a/src/util/music/chords.js
+++ b/src/util/music/chords.js
@@ -27,8 +27,8 @@ class Chord {
 }
 
 export const triads = [
-  new Chord("Duuri", [[PERFECT, UNISON], [MAJOR, THIRD], [PERFECT, FIFTH]]),
-  new Chord("Molli", [[PERFECT, UNISON], [MINOR, THIRD], [PERFECT, FIFTH]]),
+  new Chord("Duuri", [[MAJOR, THIRD], [PERFECT, FIFTH]]),
+  new Chord("Molli", [[MINOR, THIRD], [PERFECT, FIFTH]]),
   new Chord("Vähennetty", [[MINOR, THIRD], [DIMINISHED, FIFTH]]),
   new Chord("Ylinouseva", [[MAJOR, THIRD], [AUGMENTED, FIFTH]]),
 ]

--- a/src/util/music/intervals.js
+++ b/src/util/music/intervals.js
@@ -20,8 +20,7 @@ class Interval {
   notation(root) {
     return (
       "L:1/1\n[" +
-      root.notation +
-      interval(root, this.quality.name, this.number) +
+      concatenate(root, [[PERFECT, UNISON], [this.quality.name, this.number]]) +
       "]"
     )
   }

--- a/src/util/music/scales.js
+++ b/src/util/music/scales.js
@@ -24,9 +24,11 @@ class Scale {
   notation(root) {
     return (
       "L:1/4\n" +
-      root.notation +
-      concatenate(root, this.intervals) +
-      root.notation
+      concatenate(root, [
+        [PERFECT, UNISON],
+        ...this.intervals,
+        [PERFECT, UNISON],
+      ])
     )
   }
 }


### PR DESCRIPTION
The notation() for augmented unison didn't put the natural
accidental when needed, so that the notation and the sound
were those of a perfect unison. Now each notation() function
in chords, intervals and scales uses concatenate for every
note, including the root, so that the natural symbol is
added when needed.