### PR TITLE
Fix onCorrectAnswer crashing when no response

### DIFF
--- a/src/components/music/MusicExerciseWrapper.js
+++ b/src/components/music/MusicExerciseWrapper.js
@@ -155,7 +155,12 @@ class MusicExerciseWrapper extends React.Component {
     }
 
     if (correctAnswers >= this.state.requiredAnswers) {
-      const res = await this.sendAnswer(textData, true)
+      let res
+      try {
+        res = await this.sendAnswer(textData, true)
+      } catch {
+        res = {}
+      }
       const pointsAwarded = res.userQuizState
         ? res.userQuizState.pointsAwarded
         : null


### PR DESCRIPTION
When sending information abuot a correct answer to the backend,
there was no error checking, so if no answer came, function
onCorrectAnswer just stopped and failed to set needed values
to state (namely pointsError).