### PR TITLE
Inform user if quiz data was not received

### DIFF
--- a/src/components/music/MusicExerciseWrapper.js
+++ b/src/components/music/MusicExerciseWrapper.js
@@ -362,7 +362,6 @@ class MusicExerciseWrapper extends React.Component {
   }
 
   render() {
-    console.log({ quizzzzzzzzid: this.state.quizItemId })
     if (!this.state.render) {
       return <Loading loading={!this.state.render} heightHint="350px" />
     }

--- a/src/components/music/MusicExerciseWrapper.js
+++ b/src/components/music/MusicExerciseWrapper.js
@@ -101,7 +101,6 @@ class MusicExerciseWrapper extends React.Component {
     try {
       res = await getQuizData(this.props.quizId)
     } catch {
-      // add logic to inform the user of the error
       this.setState({ render: true })
       return
     }
@@ -321,7 +320,7 @@ class MusicExerciseWrapper extends React.Component {
             ) : (
               <div>
                 <LoginNag>
-                  Kirjaudu sisään saadaksesi tehtävanannosta pisteitä.
+                  Kirjaudu sisään saadaksesi tehtävästä pisteitä.
                 </LoginNag>
                 <LoginNagWrapper>
                   <LoginControls />
@@ -342,12 +341,13 @@ class MusicExerciseWrapper extends React.Component {
 
           {(this.context.loggedIn || this.state.skipLogin) && (
             <Loading loading={this.state.loader} heightHint="305px">
-              {!this.context.loggedIn && (
-                <Typography color="secondary">
-                  Et saa tekemistäsi tehtävistä pisteitä ennen kuin kirjaudut
-                  sisään.
-                </Typography>
-              )}
+              <Typography color="secondary">
+                {!this.context.loggedIn
+                  ? "Et saa tekemistäsi tehtävistä pisteitä ennen kuin kirjaudut sisään."
+                  : !this.state.quizItemId
+                  ? "Tapahtui virhe tehtävän tietojen lataamisessa palvelimelta. Ole hyvä ja lataa sivu uudelleen, jos haluat saada tehtävästä pisteitä."
+                  : ""}
+              </Typography>
               {this.props.description && <p>{this.props.description}</p>}
               {this.props.renderExercise(
                 this.onCorrectAnswer,
@@ -362,6 +362,7 @@ class MusicExerciseWrapper extends React.Component {
   }
 
   render() {
+    console.log({ quizzzzzzzzid: this.state.quizItemId })
     if (!this.state.render) {
       return <Loading loading={!this.state.render} heightHint="350px" />
     }


### PR DESCRIPTION
If the request for quiz data doesn't get a response
from the server, quizItemId is not known, thus the user
can't get points once the exercise is completed. Now
the user is informed that quiz data wasn't received,
and can decide to reload the page if interested in
getting points registered when the exercise is completed.