### PR TITLE
Modify interval so that it returns also pitch

### DIFF
--- a/src/util/music/__tests__/chords.test.js
+++ b/src/util/music/__tests__/chords.test.js
@@ -36,6 +36,6 @@ describe("interval()", () => {
     for (const root of roots)
       for (const chord of triads)
         for (const i of chord.intervals)
-          expect(interval(root, ...i)).toBeTruthy()
+          expect(interval(root, ...i).notation).toBeTruthy()
   })
 })

--- a/src/util/music/__tests__/intervals.test.js
+++ b/src/util/music/__tests__/intervals.test.js
@@ -10,75 +10,75 @@ import { qualities } from "../qualities"
 describe("interval()", () => {
   it("returns D sharp as E's major seventh", () => {
     const e = roots[6]
-    expect(interval(e, "maj", 7)).toBe("^d")
+    expect(interval(e, "maj", 7).notation).toBe("^d")
   })
   it("returns E flat as F sharp's diminished seventh", () => {
     const fSharp = roots[8]
-    expect(interval(fSharp, "dim", 7)).toBe("_e")
+    expect(interval(fSharp, "dim", 7).notation).toBe("_e")
   })
   it("returns F flat as G flat's minor fourteenth", () => {
     const gFlat = roots[9]
-    expect(interval(gFlat, "min", 14)).toBe("_f'")
+    expect(interval(gFlat, "min", 14).notation).toBe("_f'")
   })
   it("returns F sharp as A sharp's minor sixth", () => {
     const aSharp = roots[14]
-    expect(interval(aSharp, "min", 6)).toBe("^f")
+    expect(interval(aSharp, "min", 6).notation).toBe("^f")
   })
   it("returns C flat as E's diminished thirteenth", () => {
     const e = roots[6]
-    expect(interval(e, "dim", 13)).toBe("_c'")
+    expect(interval(e, "dim", 13).notation).toBe("_c'")
   })
   it("returns B double flat as E flat's diminished fifth", () => {
     const eFlat = roots[5]
-    expect(interval(eFlat, "dim", 5)).toBe("__B")
+    expect(interval(eFlat, "dim", 5).notation).toBe("__B")
   })
   it("returns C as F sharp's diminished twelfth", () => {
     const fSharp = roots[8]
-    expect(interval(fSharp, "dim", 12)).toBe("c'")
+    expect(interval(fSharp, "dim", 12).notation).toBe("c'")
   })
   it("returns G as C's perfect twelfth", () => {
     const c = roots[0]
-    expect(interval(c, "perf", 12)).toBe("g")
+    expect(interval(c, "perf", 12).notation).toBe("g")
   })
   it("returns D sharp as A's augmented fourth", () => {
     const a = roots[13]
-    expect(interval(a, "aug", 4)).toBe("^d")
+    expect(interval(a, "aug", 4).notation).toBe("^d")
   })
   it("returns C flat as G's diminished eleventh", () => {
     const g = roots[10]
-    expect(interval(g, "dim", 11)).toBe("_c'")
+    expect(interval(g, "dim", 11).notation).toBe("_c'")
   })
   it("returns F flat as D flat's minor third", () => {
     const dFlat = roots[2]
-    expect(interval(dFlat, "min", 3)).toBe("_F")
+    expect(interval(dFlat, "min", 3).notation).toBe("_F")
   })
   it("returns G as E flat's major tenth", () => {
     const eFlat = roots[5]
-    expect(interval(eFlat, "maj", 10)).toBe("g")
+    expect(interval(eFlat, "maj", 10).notation).toBe("g")
   })
   it("returns A double sharp as G sharp's augmented second", () => {
     const gSharp = roots[11]
-    expect(interval(gSharp, "aug", 2)).toBe("^^A")
+    expect(interval(gSharp, "aug", 2).notation).toBe("^^A")
   })
   it("returns A flat as G's minor second", () => {
     const g = roots[10]
-    expect(interval(g, "min", 2)).toBe("_A")
+    expect(interval(g, "min", 2).notation).toBe("_A")
   })
   it("returns C as B flat's major ninth", () => {
     const bFlat = roots[15]
-    expect(interval(bFlat, "maj", 9)).toBe("c'")
+    expect(interval(bFlat, "maj", 9).notation).toBe("c'")
   })
   it("returns D as D's unison", () => {
     const d = roots[3]
-    expect(interval(d, "perf", 1)).toBe("D")
+    expect(interval(d, "perf", 1).notation).toBe("D")
   })
   it("returns B sharp as B's augmented octave", () => {
     const b = roots[16]
-    expect(interval(b, "aug", 8)).toBe("^b")
+    expect(interval(b, "aug", 8).notation).toBe("^b")
   })
   it("returns E flat as E's diminished octave", () => {
     const e = roots[6]
-    expect(interval(e, "dim", 8)).toBe("_e")
+    expect(interval(e, "dim", 8).notation).toBe("_e")
   })
 })
 
@@ -88,6 +88,6 @@ describe("interval()", () => {
     for (const root of roots)
       for (const quality of qualities)
         for (const number of intervalsForQualities[quality.name])
-          expect(interval(root, quality.name, number)).toBeTruthy()
+          expect(interval(root, quality.name, number).notation).toBeTruthy()
   })
 })

--- a/src/util/music/__tests__/scales.test.js
+++ b/src/util/music/__tests__/scales.test.js
@@ -110,6 +110,6 @@ describe("interval()", () => {
     for (const root of roots)
       for (const scale of [...scales, ...modes])
         for (const i of scale.intervals)
-          expect(interval(root, ...i)).toBeTruthy()
+          expect(interval(root, ...i).notation).toBeTruthy()
   })
 })

--- a/src/util/music/intervals.js
+++ b/src/util/music/intervals.js
@@ -110,13 +110,15 @@ export const raiseOctave = input => {
 const pitchJumps = [0, 2, 4, 5, 7, 9, 11]
 
 /**
- * Returns String corresponding to abc notation for adding an interval symbol
- * on top of root.
+ * Returns an object with:
+ * "notation": a String corresponding to abc notation for adding an interval on
+ *             top of the given root;
+ * "pitch": the corresponding pitch, from 0 to 11.
  *
  * For example:
  *    root = roots[0] // C
  *    interval(root, MAJOR, THIRD)
- *    returns "E"
+ *    returns { notation: "E", pitch: 4 }
  *
  * @param {*} root Root note for the interval
  * @param {*} quality What quality the interval should have
@@ -165,13 +167,14 @@ export const interval = (root, quality, number) => {
   for now only 1 -> 14 intervals are supported
   */
   let notation = ""
-  for (const note of notes[
-    (root.pitch + pitchJump + notes.length) % notes.length
-  ])
+  const pitch = (root.pitch + pitchJump + notes.length) % notes.length
+  for (const note of notes[pitch])
     if (note.includes(letter))
       notation = lowercaseLetter ? note.toLowerCase() : note
 
-  return compound ? raiseOctave(notation) : notation
+  notation = compound ? raiseOctave(notation) : notation
+
+  return { notation, pitch }
 }
 
 /**
@@ -189,7 +192,7 @@ export const interval = (root, quality, number) => {
  * @param {*} intervals Desired notes, expressed as intervals from the root
  */
 export const concatenate = (root, intervals) =>
-  concatenateNotes(intervals.map(i => interval(root, ...i)))
+  concatenateNotes(intervals.map(i => interval(root, ...i).notation))
 
 export const concatenateNotes = notes => {
   let prevAccidentals = ""


### PR DESCRIPTION
We need to know the pitch of an interval to easily
check a correct answer for PianoExercise, so now
interval() returns an object which includes pitch.