### PR TITLE
Prevent addition of too many accidental signs in piano exercise

### DIFF
--- a/src/components/music/PianoExercise.js
+++ b/src/components/music/PianoExercise.js
@@ -141,6 +141,10 @@ class PianoExercise extends React.Component {
 
   appendNote = note => {
     const { notes } = this.state
+
+    //Add the same note only once
+    if (notes.map(n => n.notation).includes(note.notation)) return
+
     notes.push(note)
     this.setState({ notes })
   }


### PR DESCRIPTION
Check if the played note has already been played, and if it has, don't write it again. This approach doesn't work if the user wants to write the same notes several times (e.g. scales).