### PR TITLE
Enforce minimum playback duration for piano keys

### DIFF
--- a/src/components/music/SoundfontProvider.js
+++ b/src/components/music/SoundfontProvider.js
@@ -76,7 +76,8 @@ class SoundfontProvider extends React.Component {
         return
       }
       const audioNode = this.state.activeAudioNodes[midiNumber]
-      audioNode.stop()
+      // enforce a minumum playback duration when clicking a key very quickly
+      setTimeout(() => audioNode.stop(), 230)
       this.setState({
         activeAudioNodes: Object.assign({}, this.state.activeAudioNodes, {
           [midiNumber]: null,


### PR DESCRIPTION
Clicking a piano key very quickly resulted in a very
short playback, and it seemed like the piano didn't
play at all. Now there's a short delay between releasing
a piano key and stopping its playback, ensuring a minimum
playback duration, even when clicking very quickly.