### PR TITLE
Moved Chord specific things out of PianoExercise

### DIFF
--- a/src/components/music/Chord.js
+++ b/src/components/music/Chord.js
@@ -1,10 +1,11 @@
+import React from "react"
 import {
   roots as notationRoots,
   answerOptionsForRoots as answerRoots,
 } from "../../util/music/roots"
 import { triads as answerTriads } from "../../util/music/chords"
 import { randomIntArray } from "../../util/random"
-import { interval } from "../../util/music/intervals"
+import { interval, concatenateNotes } from "../../util/music/intervals"
 
 // Answer Keys
 const ROOT = "root",
@@ -143,6 +144,35 @@ export default class Chord {
     }
   }
 
+  /**
+   * Check if the answer is correct for a Piano exercise.
+   * @param {*} pianoAnswerNotes Notes the student has pressed on piano
+   * @param {*} correctAnswer Correct answer (from generateCorrectAnswers)
+   */
+  isPianoAnswerCorrect = (pianoAnswerNotes, correctAnswer) => {
+    const correctAnswerNotes = this.getAnswerAsNotes(correctAnswer)
+    if (pianoAnswerNotes.length === correctAnswerNotes.length) {
+      return correctAnswerNotes.every(pitch => pianoAnswerNotes.includes(pitch))
+    }
+    return false
+  }
+
+  /**
+   * Should the next note be added.
+   * @param {*} note Note given by piano
+   * @param {*} notes already added notes
+   */
+  shouldAddNote = (note, notes) => {
+    return (
+      notes.length <= this.getNoteLimits().max &&
+      !notes.map(n => n.notation).includes(note.notation)
+    )
+  }
+
+  /**
+   * Turn correct answer into an array of notes
+   * @param {*} correctAnswer Correct answer (from generateCorrectAnswers)
+   */
   getAnswerAsNotes(correctAnswer) {
     return [
       correctAnswer.pitch,
@@ -150,6 +180,23 @@ export default class Chord {
         i => interval(notationRoots[correctAnswer.root], ...i).pitch,
       ),
     ]
+  }
+
+  /**
+   * Form abc notation from the notes given by piano.
+   * @param {*} notes notes given by piano
+   */
+  getNotesAsNotation(notes) {
+    return "L:1/1\n[" + concatenateNotes(notes.map(n => n.notation)) + "]"
+  }
+
+  getPianoInstructions = correctAnswer => {
+    const asString = this.readableAnswerString(correctAnswer)
+    return (
+      <>
+        Muodosta pianon avulla <b>{asString}</b> kolmisointuna
+      </>
+    )
   }
 
   /**

--- a/src/components/music/Chord.js
+++ b/src/components/music/Chord.js
@@ -164,7 +164,7 @@ export default class Chord {
    */
   shouldAddNote = (note, notes) => {
     return (
-      notes.length <= this.getNoteLimits().max &&
+      notes.length < this.getNoteLimits().max &&
       !notes.map(n => n.notation).includes(note.notation)
     )
   }


### PR DESCRIPTION
Moved correct answer checking, instructions & note press->addition limits from PianoExercise to Chord

New methods added to exerciseKind (Chord):

Method | what it does
-- | --
`isPianoAnswerCorrect` | Checks if given notes (piano) match correctAnswer (generated in Chord)
`shouldAddNote` | Checks if new note should be added to the given array of notes
`getNotesAsNotation` | Turns notes given by piano to proper abc notation
`getPianoInstructions` | Instructions for the piano exercise

Removed from PianoExercise:

- `isAnswerCorrect` method