### PR TITLE
Fix rendering of correct notes in piano exercises

### DIFF
--- a/src/components/music/Chord.js
+++ b/src/components/music/Chord.js
@@ -184,6 +184,17 @@ export default class Chord {
   }
 
   /**
+   * Returns an array of correct notations to be used when writing on the score.
+   * @param {*} correctAnswer Correct answer (from generateCorrectAnswers)
+   */
+  getNotationForMidi = correctAnswer => [
+    correctAnswer.root.notation,
+    ...answerTriads[correctAnswer.triad].intervals.map(
+      i => interval(notationRoots[correctAnswer.root], ...i).notation,
+    ),
+  ]
+
+  /**
    * Form abc notation from the notes given by piano.
    * @param {*} notes notes given by piano
    */

--- a/src/components/music/Interval.js
+++ b/src/components/music/Interval.js
@@ -208,6 +208,18 @@ export default class Interval {
   }
 
   /**
+   * Returns an array of correct notations to be used when writing on the score.
+   * @param {*} correctAnswer Correct answer (from generateCorrectAnswers)
+   */
+  getNotationForMidi = correctAnswer => {
+    const correctRoot = notationRoots[correctAnswer.root]
+    const quality = qualities[correctAnswer.quality].name
+    const number = correctAnswer.interval + 1 // Number is one higher than index
+    const correctInterval = interval(correctRoot, quality, number)
+    return [correctRoot.notation, correctInterval.notation]
+  }
+
+  /**
    * Form abc notation from the notes given by piano.
    * @param {*} notes notes given by piano
    */

--- a/src/components/music/Piano.js
+++ b/src/components/music/Piano.js
@@ -51,7 +51,6 @@ class Piano extends React.Component {
             appendNote={this.props.appendNote}
             hostname={soundfontHostname}
             audioContext={this.state.audioContext}
-            currentExercise={this.props.currentExercise}
             render={({ isLoading, playNote, stopNote }) => (
               <ReactPiano
                 noteRange={noteRange}

--- a/src/components/music/PianoExercise.js
+++ b/src/components/music/PianoExercise.js
@@ -3,6 +3,7 @@ import MusicSheet from "../../partials/MusicSheet"
 import CheckAnswerPopper from "./CheckAnswerPopper"
 import { Paper, Button, Icon } from "@material-ui/core"
 import withSimpleErrorBoundary from "../../util/withSimpleErrorBoundary"
+import { convertMidiNumberToNote } from "../../util/music/pianoToNotation"
 import Piano from "./Piano"
 import Loading from "../Loading"
 import SubmitButton from "./SubmitButton"
@@ -175,9 +176,19 @@ class PianoExercise extends React.Component {
 
   handleChange = () => this.setState({ checked: !this.state.checked })
 
-  appendNote = note => {
+  appendNote = midiNumber => {
     const { notes } = this.state
-    const { shouldAddNote } = this.props.exerciseKind
+    const { shouldAddNote, getNotationForMidi } = this.props.exerciseKind
+
+    const currentExercise = this.state.exerciseSet.exercises[
+      this.state.currentExerciseIndex
+    ]
+
+    const notationForMidi = getNotationForMidi(currentExercise)
+    const note = convertMidiNumberToNote(
+      midiNumber,
+      notationForMidi.map(n => n.toUpperCase()),
+    )
 
     if (!shouldAddNote(note, notes)) return
 
@@ -225,11 +236,7 @@ class PianoExercise extends React.Component {
       )
     } else {
       piano = (
-        <Piano
-          appendNote={this.appendNote}
-          isPlaying={this.state.isPlaying}
-          currentExercise={currentExercise}
-        />
+        <Piano appendNote={this.appendNote} isPlaying={this.state.isPlaying} />
       )
     }
 

--- a/src/components/music/Scale.js
+++ b/src/components/music/Scale.js
@@ -6,7 +6,7 @@ import {
 import { modes, scales } from "../../util/music/scales"
 import { concatenateNotes, interval } from "../../util/music/intervals"
 import { PERFECT } from "../../util/music/qualities"
-import { OCTAVE } from "../../util/music/intervals"
+import { UNISON, OCTAVE } from "../../util/music/intervals"
 import { randomIntArray } from "../../util/random"
 
 // Answer Keys
@@ -186,12 +186,18 @@ export default class Scale {
   getAnswerAsNotes = correctAnswer => {
     // the first empty object is the root, which we don't need
     return [
-      {},
-      ...[...this.scales[correctAnswer.scale].intervals, [PERFECT, OCTAVE]].map(
-        i => interval(notationRoots[correctAnswer.root], ...i),
-      ),
-    ]
+      [PERFECT, UNISON],
+      ...this.scales[correctAnswer.scale].intervals,
+      [PERFECT, OCTAVE],
+    ].map(i => interval(notationRoots[correctAnswer.root], ...i))
   }
+
+  /**
+   * Returns an array of correct notations to be used when writing on the score.
+   * @param {*} correctAnswer Correct answer (from generateCorrectAnswers)
+   */
+  getNotationForMidi = correctAnswer =>
+    this.getAnswerAsNotes(correctAnswer).map(note => note.notation)
 
   /**
    * Should the next note be added.

--- a/src/components/music/SoundfontProvider.js
+++ b/src/components/music/SoundfontProvider.js
@@ -1,7 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
 import Soundfont from "soundfont-player"
-import { convertMidiNumberToNote } from "../../util/music/pianoToNotation"
 
 // from https://codesandbox.io/s/7wq15pm1n1
 
@@ -66,8 +65,7 @@ class SoundfontProvider extends React.Component {
       })
     })
     // here starts the logic to write the score
-    const correctNotation = this.props.currentExercise.notation.toUpperCase()
-    this.props.appendNote(convertMidiNumberToNote(midiNumber, correctNotation))
+    this.props.appendNote(midiNumber)
   }
 
   stopNote = midiNumber => {


### PR DESCRIPTION
Sometimes when the user pressed a note which was part of the correct
answer, that note was still rendered as an incorrect enharmonic; for
example, in Ab natural minor scale, Cb was rendered as B.

Before, the correct notation was searched from within a string
corresponding to the notation of the correct answer, which is
returned from concatenateNotes. In the previous example, when the
user presses the B key on the piano, chooseFromNoteOptions searches
"B" into the correct notation string, which is "_A_B_c_d_e_f_g_a",
finds "B" and accepts it as the correct alternative, while the "B"
in the correct notation string is actually part of the notation for
the note "_B".

Now, the correct notation is searched from within a list of strings,
in which each string corresponds to the notation for one note. So
now "B" isn't found into the list (the list includes "_B", not "B"),
and the correct choice "_C" is selected.

There is still the problem of notes being sometimes rendered in the
wrong octave.