### PR TITLE
Fix chord piano exercise bug

### DIFF
--- a/src/components/music/Chord.js
+++ b/src/components/music/Chord.js
@@ -188,7 +188,7 @@ export default class Chord {
    * @param {*} correctAnswer Correct answer (from generateCorrectAnswers)
    */
   getNotationForMidi = correctAnswer => [
-    correctAnswer.root.notation,
+    notationRoots[correctAnswer.root].notation,
     ...answerTriads[correctAnswer.triad].intervals.map(
       i => interval(notationRoots[correctAnswer.root], ...i).notation,
     ),


### PR DESCRIPTION
Playing the piano in the piano chord exercised
caused the app to crash. This bug was introduced
recently, in #235.