### PR TITLE
Disabled undo & clear when playing sound

### DIFF
--- a/src/components/music/PianoExercise.js
+++ b/src/components/music/PianoExercise.js
@@ -263,7 +263,7 @@ class PianoExercise extends React.Component {
             </MusicSheet>
             <div className="dropDown1">
               <Button
-                disabled={!this.state.notes.length}
+                disabled={!this.state.notes.length || this.state.isPlaying}
                 variant="outlined"
                 onClick={this.undoNote}
               >
@@ -272,7 +272,7 @@ class PianoExercise extends React.Component {
             </div>
             <div className="dropDown2">
               <Button
-                disabled={!this.state.notes.length}
+                disabled={!this.state.notes.length || this.state.isPlaying}
                 variant="outlined"
                 title="Tyhjennä"
                 onClick={this.clearNotes}


### PR DESCRIPTION
This prevents a bug where undo or clear causes the piano to jam as disabled if undo or clear was pressed when the play button was pressed