### PR TITLE
 Fix wrong octave note rendering for Cb and B#

### DIFF
--- a/src/components/music/Chord.js
+++ b/src/components/music/Chord.js
@@ -5,7 +5,8 @@ import {
 } from "../../util/music/roots"
 import { triads as answerTriads } from "../../util/music/chords"
 import { randomIntArray } from "../../util/random"
-import { interval, concatenateNotes } from "../../util/music/intervals"
+import { UNISON, interval, concatenateNotes } from "../../util/music/intervals"
+import { PERFECT } from "../../util/music/qualities"
 
 // Answer Keys
 const ROOT = "root",
@@ -126,7 +127,7 @@ export default class Chord {
 
   makePianoAnswerPayload(
     answerNotes,
-    correctAnswerPitches,
+    correctAnswerNotes,
     correctAnswerString,
     correct,
   ) {
@@ -138,7 +139,7 @@ export default class Chord {
       },
       correctAnswer: {
         string: correctAnswerString,
-        pitch: correctAnswerPitches,
+        pitch: correctAnswerNotes.map(n => n.pitch),
       },
       correct,
     }
@@ -153,7 +154,7 @@ export default class Chord {
     const answerNotes = pianoAnswerNotes.map(n => n.pitch)
     const correctAnswerNotes = this.getAnswerAsNotes(correctAnswer)
     if (answerNotes.length === correctAnswerNotes.length) {
-      return correctAnswerNotes.every(pitch => answerNotes.includes(pitch))
+      return correctAnswerNotes.every(note => answerNotes.includes(note.pitch))
     }
     return false
   }
@@ -176,23 +177,10 @@ export default class Chord {
    */
   getAnswerAsNotes(correctAnswer) {
     return [
-      correctAnswer.pitch,
-      ...answerTriads[correctAnswer.triad].intervals.map(
-        i => interval(notationRoots[correctAnswer.root], ...i).pitch,
-      ),
-    ]
+      [PERFECT, UNISON],
+      ...answerTriads[correctAnswer.triad].intervals,
+    ].map(i => interval(notationRoots[correctAnswer.root], ...i))
   }
-
-  /**
-   * Returns an array of correct notations to be used when writing on the score.
-   * @param {*} correctAnswer Correct answer (from generateCorrectAnswers)
-   */
-  getNotationForMidi = correctAnswer => [
-    notationRoots[correctAnswer.root].notation,
-    ...answerTriads[correctAnswer.triad].intervals.map(
-      i => interval(notationRoots[correctAnswer.root], ...i).notation,
-    ),
-  ]
 
   /**
    * Form abc notation from the notes given by piano.

--- a/src/components/music/Interval.js
+++ b/src/components/music/Interval.js
@@ -1,12 +1,13 @@
 import React from "react"
 import { roots as notationRoots } from "../../util/music/roots"
 import {
+  UNISON,
   interval,
   intervalLabels,
   availableIntervals,
   concatenateNotes,
 } from "../../util/music/intervals"
-import { qualities } from "../../util/music/qualities"
+import { PERFECT, qualities } from "../../util/music/qualities"
 
 import { randomIntArray } from "../../util/random"
 
@@ -132,7 +133,7 @@ export default class Interval {
 
   makePianoAnswerPayload(
     answerNotes,
-    correctAnswerPitches,
+    correctAnswerNotes,
     correctAnswerString,
     correct,
   ) {
@@ -144,7 +145,7 @@ export default class Interval {
       },
       correctAnswer: {
         string: correctAnswerString,
-        pitch: correctAnswerPitches,
+        pitch: correctAnswerNotes.map(n => n.pitch),
       },
       correct,
     }
@@ -163,16 +164,13 @@ export default class Interval {
     )
 
     // Get correct information from the generated answer
-    const correctRoot = notationRoots[correctAnswer.root]
-    const quality = qualities[correctAnswer.quality].name
-    const number = correctAnswer.interval + 1 // Number is one higher than index
-    const correctInterval = interval(correctRoot, quality, number)
+    const correctNotes = this.getAnswerAsNotes(correctAnswer)
+    const correctPitches = correctNotes.map(n => n.pitch)
 
-    const correctPitches = [correctRoot.pitch, correctInterval.pitch]
     for (const note of pianoAnswerNotes)
       if (!correctPitches.includes(note.pitch)) return false
 
-    return enteredPitchJump === Math.abs(correctInterval.pitchJump)
+    return enteredPitchJump === Math.abs(correctNotes[1].pitchJump)
   }
 
   /**
@@ -195,20 +193,9 @@ export default class Interval {
     const correctRoot = notationRoots[correctAnswer.root]
     const quality = qualities[correctAnswer.quality].name
     const number = correctAnswer.interval + 1 // Number is one higher than index
-    const correctInterval = interval(correctRoot, quality, number)
-    return [correctRoot.pitch, correctInterval.pitch]
-  }
-
-  /**
-   * Returns an array of correct notations to be used when writing on the score.
-   * @param {*} correctAnswer Correct answer (from generateCorrectAnswers)
-   */
-  getNotationForMidi = correctAnswer => {
-    const correctRoot = notationRoots[correctAnswer.root]
-    const quality = qualities[correctAnswer.quality].name
-    const number = correctAnswer.interval + 1 // Number is one higher than index
-    const correctInterval = interval(correctRoot, quality, number)
-    return [correctRoot.notation, correctInterval.notation]
+    return [[PERFECT, UNISON], [quality, number]].map(i =>
+      interval(correctRoot, ...i),
+    )
   }
 
   /**

--- a/src/components/music/PianoExercise.js
+++ b/src/components/music/PianoExercise.js
@@ -3,6 +3,7 @@ import MusicSheet from "../../partials/MusicSheet"
 import CheckAnswerPopper from "./CheckAnswerPopper"
 import { Paper, Button, Icon } from "@material-ui/core"
 import withSimpleErrorBoundary from "../../util/withSimpleErrorBoundary"
+import { notes as notesByPitch } from "../../util/music/roots"
 import { convertMidiNumberToNote } from "../../util/music/pianoToNotation"
 import Piano from "./Piano"
 import Loading from "../Loading"
@@ -76,7 +77,7 @@ class PianoExercise extends React.Component {
   onSubmit = clickEvent => {
     const { currentTarget } = clickEvent
 
-    // Funktioita ExerciseKind (Chord, Interval, Scale)
+    // Functions from ExerciseKind (Chord, Interval, Scale)
     const {
       getNoteLimits,
       isPianoAnswerCorrect,
@@ -178,17 +179,22 @@ class PianoExercise extends React.Component {
 
   appendNote = midiNumber => {
     const { notes } = this.state
-    const { shouldAddNote, getNotationForMidi } = this.props.exerciseKind
+    const { shouldAddNote, getAnswerAsNotes } = this.props.exerciseKind
 
     const currentExercise = this.state.exerciseSet.exercises[
       this.state.currentExerciseIndex
     ]
 
-    const notationForMidi = getNotationForMidi(currentExercise)
-    const note = convertMidiNumberToNote(
-      midiNumber,
-      notationForMidi.map(n => n.toUpperCase()),
-    )
+    // here decide how to write each of the 12 notes to the score
+    // for example, should we write D# or Eb
+    const notesForMidi = getAnswerAsNotes(currentExercise)
+    const noteOptions = []
+    // set the correct notation for the notes in the correct answer
+    notesForMidi.forEach(note => (noteOptions[note.pitch] = note.zeroNotation))
+    // set the default choice for the notes not in the correct answer
+    for (let i = 0; i < notesByPitch.length; i++)
+      if (!noteOptions[i]) noteOptions[i] = notesByPitch[i][0]
+    const note = convertMidiNumberToNote(midiNumber, noteOptions)
 
     if (!shouldAddNote(note, notes)) return
 

--- a/src/components/music/Scale.js
+++ b/src/components/music/Scale.js
@@ -193,13 +193,6 @@ export default class Scale {
   }
 
   /**
-   * Returns an array of correct notations to be used when writing on the score.
-   * @param {*} correctAnswer Correct answer (from generateCorrectAnswers)
-   */
-  getNotationForMidi = correctAnswer =>
-    this.getAnswerAsNotes(correctAnswer).map(note => note.notation)
-
-  /**
    * Should the next note be added.
    * @param {*} note Note given by piano
    * @param {*} notes already added notes

--- a/src/util/music/intervals.js
+++ b/src/util/music/intervals.js
@@ -106,6 +106,34 @@ export const raiseOctave = input => {
   return output
 }
 
+/**
+ * Takes as argument a String in abc notation and returns a String in abc
+ * notation corresponding to the input notation lowered an octave.
+ * Please note that the input notation must not contain any header.
+ *
+ * For example:
+ *    lowerOctave("_B, g'^F") returns "_B, g^F,"
+ *
+ * @param {*} input A String in abc notation
+ */
+export const lowerOctave = input => {
+  let output = ""
+  for (let i = 0; i < input.length; i++) {
+    if (input.charAt(i).match(/[a-g]/)) {
+      if (input.charAt(i + 1) && input.charAt(i + 1) === "'") {
+        output += input.charAt(i++)
+      } else {
+        output += input.charAt(i).toUpperCase()
+      }
+    } else if (input.charAt(i).match(/[A-G]/)) {
+      output += input.charAt(i) + ","
+    } else {
+      output += input.charAt(i)
+    }
+  }
+  return output
+}
+
 // pitchJumps assume PERFECT and MAJOR quality
 const pitchJumps = [0, 2, 4, 5, 7, 9, 11]
 
@@ -128,18 +156,17 @@ export const interval = (root, quality, number) => {
   // When the interval is an octave or bigger (compound interval), first make
   // the simple interval (less than an octave), later raise it one octave
   let compound = false
+  let octavesToRaise = 0
   if (number > SEVENTH) {
     number -= letters.length
     compound = true
+    octavesToRaise++
   }
 
   // How many letters the letter jumps to go to
   const letterJump = number - 1
 
   const letter = letters[(root.letter + letterJump) % letters.length]
-  // abc notation uses lowercase for the higher octave, i.e. the 5th octave in
-  // scientific pitch notation
-  const lowercaseLetter = root.letter + letterJump >= letters.length
 
   // How many semitones the pitch jumps
   let pitchJump = pitchJumps[letterJump]
@@ -166,18 +193,38 @@ export const interval = (root, quality, number) => {
   (like perfect third or minor fourth)
   for now only 1 -> 14 intervals are supported
   */
-  let notation = ""
   const pitch = (root.pitch + pitchJump + notes.length) % notes.length
+  if (root.pitch + pitchJump >= notes.length) {
+    octavesToRaise++
+  } else if (root.pitch + pitchJump < 0) {
+    // needed for diminished unison
+    octavesToRaise--
+  }
+
+  let notation = ""
   for (const note of notes[pitch])
-    if (note.includes(letter))
-      notation = lowercaseLetter ? note.toLowerCase() : note
+    if (note.toUpperCase().includes(letter)) {
+      notation = note
+    }
+  // notation if the note was in the central octave
+  const zeroNotation = notation
+
+  // needed for diminished unison
+  while (octavesToRaise < 0) {
+    notation = lowerOctave(notation)
+    octavesToRaise++
+  }
+
+  while (octavesToRaise > 0) {
+    notation = raiseOctave(notation)
+    octavesToRaise--
+  }
 
   if (compound) {
-    notation = raiseOctave(notation)
     pitchJump += notes.length
   }
 
-  return { notation, pitch, pitchJump }
+  return { notation, zeroNotation, pitch, pitchJump }
 }
 
 /**

--- a/src/util/music/pianoToNotation.js
+++ b/src/util/music/pianoToNotation.js
@@ -1,46 +1,38 @@
+import { lowerOctave, raiseOctave } from "./intervals"
 import { notes } from "./roots"
 
-export const convertMidiNumberToNote = (midiNumber, correctNotation) => {
+export const convertMidiNumberToNote = (midiNumber, noteOptions) => {
   const { pitch, octave } = convertMidiNumberToPitch(midiNumber)
-  const noteOptions = notes[pitch]
-  //select the option that is in the correct answer as well
-  const selectedNote = chooseFromNoteOptions(noteOptions, correctNotation)
+  // select the option that is in the correct answer as well
+  const selectedNote = noteOptions[pitch]
   const noteInRightOctave = getNoteInRightOctave(selectedNote, octave)
   return { notation: noteInRightOctave, pitch, midiNumber }
 }
 
 const convertMidiNumberToPitch = midiNumber => {
-  let pitch = midiNumber - 60 //midi number 60 = middle c
-  let octave = 1 // middle octave
-  while (pitch > 11) {
-    pitch -= 12
-    octave += 1
+  let pitch = midiNumber - 60 // midi number 60 = middle c
+  let octave = 0 // middle octave
+  while (pitch >= notes.length) {
+    pitch -= notes.length
+    octave++
   }
+  // needed only if piano range is changed
   while (pitch < 0) {
-    pitch += 12
-    octave -= 1
+    pitch += notes.length
+    octave--
   }
   return { pitch, octave, midiNumber }
 }
 
-const getNoteInRightOctave = (note, octave) => {
-  switch (octave) {
-    case 0:
-      return note + ","
-    case 1:
-      return note
-    case 2:
-      return note.toLowerCase()
-    case 3:
-      return note.toLowerCase() + "'"
+const getNoteInRightOctave = (notation, octave) => {
+  while (octave > 0) {
+    notation = raiseOctave(notation)
+    octave--
   }
-  return note
-}
-
-const chooseFromNoteOptions = (noteOptions, correctNotation) => {
-  for (let i = 0; i < noteOptions.length; i++) {
-    const noteOption = noteOptions[i]
-    if (correctNotation.includes(noteOption)) return noteOption
+  // needed only if piano range is changed
+  while (octave < 0) {
+    notation = lowerOctave(notation)
+    octave++
   }
-  return noteOptions[0]
+  return notation
 }

--- a/src/util/music/roots.js
+++ b/src/util/music/roots.js
@@ -41,7 +41,7 @@ export const letters = ["C", "D", "E", "F", "G", "A", "B"]
 // Represents notes in abc notation,
 // Grouped by pitch (elements in same row produce same sound)
 export const notes = [
-  ["C", "^B", "__D"],
+  ["C", "^B,", "__D"],
   ["_D", "^C", "^^B"],
   ["D", "^^C", "__E"],
   ["_E", "^D", "__F"],
@@ -52,7 +52,7 @@ export const notes = [
   ["_A", "^G"],
   ["A", "^^G", "__B"],
   ["_B", "^A", "__C"],
-  ["B", "_C", "^^A"],
+  ["B", "_c", "^^A"],
 ]
 
 // Indexes for roots below


### PR DESCRIPTION
In the piano exercises Cb and B# were rendered in the wrong octave.
This has been resolved by modifying the notes array in roots, so
that each subarray contains the notation for the central octave.
Then the octave logic in the interval function had to be modified
as a result, and also the octave logic in the pianoToNotation file.
This required a little refactoring in the PianoExercise files, too.