### PR TITLE
Add inversions to chord recognition exercise

### DIFF
--- a/data/osa-03/index.md
+++ b/data/osa-03/index.md
@@ -9,5 +9,6 @@ overview: true
 Sointu on monia säveliä. Soinnut ovat kivoja. Musiikki on hauskaa. Tanssitaan kaikki yhdessä sointujen kuunnellessa. Sointu on taidetta. Kolmisointu, ja muita sointuja. Sointu.
 
 <music-exercise name="Soinnun tunnistus" description="Voit myös kuunnella soinnun nappia painamalla." type="chords" required=2></music-exercise>
+<music-exercise name="Soinnun tunnistus" description="Soinnuissa on eri käännöksiä. Voit myös kuunnella soinnun nappia painamalla." type="chords_inversions"></music-exercise>
 <music-exercise name="Soinnun tunnistus" type="chords_notes"></music-exercise>
 <music-exercise name="Soinnun kirjoitus" type="piano_chords" required=2></music-exercise>

--- a/src/components/music/Chord.js
+++ b/src/components/music/Chord.js
@@ -5,7 +5,11 @@ import {
 } from "../../util/music/roots"
 import { triads as answerTriads } from "../../util/music/chords"
 import { randomIntArray } from "../../util/random"
-import { UNISON, interval, concatenateNotes } from "../../util/music/intervals"
+import {
+  UNISON,
+  interval,
+  concatenateNotation,
+} from "../../util/music/intervals"
 import { PERFECT } from "../../util/music/qualities"
 
 // Answer Keys
@@ -17,9 +21,12 @@ const ROOT = "root",
  * @param {*} howMany How many exercises to generate
  * @returns [{root: 5, triad: 4, notation: "<abc notation>"}]
  */
-const generateCorrectAnswers = howMany => {
+const generateCorrectAnswers = (howMany, withInversions) => {
   const correctRoots = randomIntArray(0, notationRoots.length, howMany)
   const correctTriads = randomIntArray(0, answerTriads.length, howMany)
+  const inversions = withInversions
+    ? randomIntArray(0, answerTriads[0].intervals.length + 1, howMany)
+    : new Array(howMany).fill(0)
 
   return correctRoots.map((root, i) => {
     const triad = correctTriads[i]
@@ -27,12 +34,19 @@ const generateCorrectAnswers = howMany => {
       root: root,
       pitch: notationRoots[root].pitch, // Generated answers have pitch
       triad: triad,
-      notation: answerTriads[triad].notation(notationRoots[root]),
+      notation: answerTriads[triad].notation(
+        notationRoots[root],
+        inversions[i],
+      ),
     }
   })
 }
 
 export default class Chord {
+  constructor(withInversions) {
+    this.withInversions = withInversions
+  }
+
   generateExerciseSet(howMany) {
     const exerciseSet = {
       answerKeys: [ROOT, TRIAD],
@@ -44,7 +58,7 @@ export default class Chord {
         root: "Pohjasävel",
         triad: "Laatu",
       },
-      exercises: generateCorrectAnswers(howMany),
+      exercises: generateCorrectAnswers(howMany, this.withInversions),
     }
 
     return exerciseSet
@@ -187,7 +201,7 @@ export default class Chord {
    * @param {*} notes notes given by piano
    */
   getNotesAsNotation(notes) {
-    return "L:1/1\n[" + concatenateNotes(notes.map(n => n.notation)) + "]"
+    return "L:1/1\n[" + concatenateNotation(notes.map(n => n.notation)) + "]"
   }
 
   getPianoInstructions = correctAnswer => {

--- a/src/components/music/Interval.js
+++ b/src/components/music/Interval.js
@@ -6,7 +6,7 @@ import {
   intervalLabels,
   availableIntervals,
   simpleIntervals,
-  concatenateNotes,
+  concatenateNotation,
 } from "../../util/music/intervals"
 import {
   PERFECT,
@@ -227,7 +227,7 @@ export default class Interval {
    * @param {*} notes notes given by piano
    */
   getNotesAsNotation = notes => {
-    return "L:1/1\n[" + concatenateNotes(notes.map(n => n.notation)) + "]"
+    return "L:1/1\n[" + concatenateNotation(notes.map(n => n.notation)) + "]"
   }
 
   getPianoInstructions = correctAnswer => {

--- a/src/components/music/Scale.js
+++ b/src/components/music/Scale.js
@@ -4,7 +4,7 @@ import {
   answerOptionsForRoots as answerRoots,
 } from "../../util/music/roots"
 import { modes, scales } from "../../util/music/scales"
-import { concatenateNotes, interval } from "../../util/music/intervals"
+import { concatenateNotation, interval } from "../../util/music/intervals"
 import { PERFECT } from "../../util/music/qualities"
 import { UNISON, OCTAVE } from "../../util/music/intervals"
 import { randomIntArray } from "../../util/random"
@@ -205,7 +205,7 @@ export default class Scale {
    * @param {*} notes notes given by piano
    */
   getNotesAsNotation(notes) {
-    return "L:1/4\n" + concatenateNotes(notes.map(n => n.notation))
+    return "L:1/4\n" + concatenateNotation(notes.map(n => n.notation))
   }
 
   getPianoInstructions = correctAnswer => {

--- a/src/partials/MusicExercise.js
+++ b/src/partials/MusicExercise.js
@@ -93,7 +93,10 @@ const createExerciseRenderingFunction = (type, requiredAnswers) => (
       <>
         <p>Incorrect exercise type {"'" + type + "'"}, implemented types:</p>
         <ul>
-          <li>chords, chords_notes, chords_sound</li>
+          <li>
+            chords, chords_notes, chords_sound, chords_intervals,
+            chords_intervals_notes, chords_intervals_sound,
+          </li>
           <li>intervals, intervals_notes, intervals_sound</li>
           <li>scales, scales_notes, scales_sound</li>
           <li>modes, modes_notes, modes_sound</li>

--- a/src/partials/MusicExercise.js
+++ b/src/partials/MusicExercise.js
@@ -63,7 +63,9 @@ const getQuizId = type => {
 }
 
 const getExerciseKindByType = type => {
-  if (type.includes("chord")) {
+  if (type.includes("chords_inversions")) {
+    return new Chord(true)
+  } else if (type.includes("chord")) {
     return new Chord()
   } else if (type.includes("intervals_sound")) {
     return new Interval("simple")

--- a/src/partials/MusicExercise.js
+++ b/src/partials/MusicExercise.js
@@ -94,8 +94,8 @@ const createExerciseRenderingFunction = (type, requiredAnswers) => (
         <p>Incorrect exercise type {"'" + type + "'"}, implemented types:</p>
         <ul>
           <li>
-            chords, chords_notes, chords_sound, chords_intervals,
-            chords_intervals_notes, chords_intervals_sound,
+            chords, chords_notes, chords_sound, chords_inversions,
+            chords_inversions_notes, chords_inversions_sound,
           </li>
           <li>intervals, intervals_notes, intervals_sound</li>
           <li>scales, scales_notes, scales_sound</li>

--- a/src/util/music/chords.js
+++ b/src/util/music/chords.js
@@ -1,6 +1,8 @@
 import { DIMINISHED, MINOR, MAJOR, PERFECT, AUGMENTED } from "./qualities"
 import {
-  concatenateIntervals,
+  concatenateNotation,
+  interval,
+  raiseOctave,
   UNISON,
   SECOND,
   THIRD,
@@ -18,10 +20,17 @@ class Chord {
     this.formattingFunction = formattingFunction
   }
 
-  notation(root) {
+  // inversion can range from 0 to this.intervals.size (both inclusive)
+  notation(root, inversion = 0) {
+    const intervalsNotations = [[PERFECT, UNISON], ...this.intervals].map(
+      i => interval(root, ...i).notation,
+    )
+    const toBeRaised = intervalsNotations.slice(0, inversion)
+    const ready = intervalsNotations.slice(inversion)
+
     return (
       "L:1/1\n[" +
-      concatenateIntervals(root, [[PERFECT, UNISON], ...this.intervals]) +
+      concatenateNotation([...ready, ...toBeRaised.map(n => raiseOctave(n))]) +
       "]"
     )
   }

--- a/src/util/music/chords.js
+++ b/src/util/music/chords.js
@@ -25,6 +25,9 @@ class Chord {
     const intervalsNotations = [[PERFECT, UNISON], ...this.intervals].map(
       i => interval(root, ...i).notation,
     )
+    // create two subarrays from intervalsNotations: one from index 0
+    // (inclusive) to index inversion (exclusive), the other from index
+    // inversion (inclusive) to the end of the array
     const toBeRaised = intervalsNotations.slice(0, inversion)
     const ready = intervalsNotations.slice(inversion)
 

--- a/src/util/music/intervals.js
+++ b/src/util/music/intervals.js
@@ -254,9 +254,9 @@ export const interval = (root, quality, number) => {
  * @param {*} intervals Desired notes, expressed as intervals from the root
  */
 export const concatenateIntervals = (root, intervals) =>
-  concatenateNotes(intervals.map(i => interval(root, ...i).notation))
+  concatenateNotation(intervals.map(i => interval(root, ...i).notation))
 
-export const concatenateNotes = notes => {
+export const concatenateNotation = notes => {
   const prevAccidentals = new Set([])
   return notes
     .map(note => {


### PR DESCRIPTION
Now the teacher can choose if chord inversions have to
be included. The student isn't asked to recognize which
inversion is displayed, only which chord type it is, and
which note is the root.