### PR TITLE
Some cleanup

### DIFF
--- a/src/components/music/PianoExercise.js
+++ b/src/components/music/PianoExercise.js
@@ -120,7 +120,7 @@ class PianoExercise extends React.Component {
       if (
         this.state.currentExerciseIndex + 1 <
         this.state.exerciseSet.exercises.length
-      )
+      ) {
         setTimeout(() => {
           // Show checkmark
           this.setState({ showCorrectOnButton: true })
@@ -129,7 +129,8 @@ class PianoExercise extends React.Component {
             this.setState({ showCorrectOnButton: false })
           }, 1000)
         }, 100)
-      this.nextExercise()
+        this.nextExercise()
+      }
     } else {
       this.props.onIncorrect(payload)
       this.setState(oldState => ({

--- a/src/util/music/__tests__/intervals.test.js
+++ b/src/util/music/__tests__/intervals.test.js
@@ -1,6 +1,30 @@
-import { interval, intervalsForQualities } from "../intervals"
+import {
+  interval,
+  intervalsForQualities,
+  UNISON,
+  SECOND,
+  THIRD,
+  FOURTH,
+  FIFTH,
+  SIXTH,
+  SEVENTH,
+  OCTAVE,
+  NINTH,
+  TENTH,
+  ELEVENTH,
+  TWELFTH,
+  THIRTEENTH,
+  FOURTEENTH,
+} from "../intervals"
 import { roots, ROOTS } from "../roots"
-import { allQualities as qualities } from "../qualities"
+import {
+  allQualities as qualities,
+  DIMINISHED,
+  MINOR,
+  MAJOR,
+  PERFECT,
+  AUGMENTED,
+} from "../qualities"
 
 /*
   These are in no way a comprehensive collection of intervals;
@@ -10,75 +34,75 @@ import { allQualities as qualities } from "../qualities"
 describe("interval()", () => {
   it("returns D sharp as E's major seventh", () => {
     const e = roots[ROOTS.E]
-    expect(interval(e, "maj", 7).notation).toBe("^d")
+    expect(interval(e, MAJOR, SEVENTH).notation).toBe("^d")
   })
   it("returns E flat as F sharp's diminished seventh", () => {
     const fSharp = roots[ROOTS.F_SHARP]
-    expect(interval(fSharp, "dim", 7).notation).toBe("_e")
+    expect(interval(fSharp, DIMINISHED, SEVENTH).notation).toBe("_e")
   })
   it("returns F flat as G flat's minor fourteenth", () => {
     const gFlat = roots[ROOTS.G_FLAT]
-    expect(interval(gFlat, "min", 14).notation).toBe("_f'")
+    expect(interval(gFlat, MINOR, FOURTEENTH).notation).toBe("_f'")
   })
   it("returns F sharp as A sharp's minor sixth", () => {
     const aSharp = roots[ROOTS.A_SHARP]
-    expect(interval(aSharp, "min", 6).notation).toBe("^f")
+    expect(interval(aSharp, MINOR, SIXTH).notation).toBe("^f")
   })
   it("returns C flat as E's diminished thirteenth", () => {
     const e = roots[ROOTS.E]
-    expect(interval(e, "dim", 13).notation).toBe("_c'")
+    expect(interval(e, DIMINISHED, THIRTEENTH).notation).toBe("_c'")
   })
   it("returns B double flat as E flat's diminished fifth", () => {
     const eFlat = roots[ROOTS.E_FLAT]
-    expect(interval(eFlat, "dim", 5).notation).toBe("__B")
+    expect(interval(eFlat, DIMINISHED, FIFTH).notation).toBe("__B")
   })
   it("returns C as F sharp's diminished twelfth", () => {
     const fSharp = roots[ROOTS.F_SHARP]
-    expect(interval(fSharp, "dim", 12).notation).toBe("c'")
+    expect(interval(fSharp, DIMINISHED, TWELFTH).notation).toBe("c'")
   })
   it("returns G as C's perfect twelfth", () => {
     const c = roots[ROOTS.C]
-    expect(interval(c, "perf", 12).notation).toBe("g")
+    expect(interval(c, PERFECT, TWELFTH).notation).toBe("g")
   })
   it("returns D sharp as A's augmented fourth", () => {
     const a = roots[ROOTS.A]
-    expect(interval(a, "aug", 4).notation).toBe("^d")
+    expect(interval(a, AUGMENTED, FOURTH).notation).toBe("^d")
   })
   it("returns C flat as G's diminished eleventh", () => {
     const g = roots[ROOTS.G]
-    expect(interval(g, "dim", 11).notation).toBe("_c'")
+    expect(interval(g, DIMINISHED, ELEVENTH).notation).toBe("_c'")
   })
   it("returns F flat as D flat's minor third", () => {
     const dFlat = roots[ROOTS.D_FLAT]
-    expect(interval(dFlat, "min", 3).notation).toBe("_F")
+    expect(interval(dFlat, MINOR, THIRD).notation).toBe("_F")
   })
   it("returns G as E flat's major tenth", () => {
     const eFlat = roots[ROOTS.E_FLAT]
-    expect(interval(eFlat, "maj", 10).notation).toBe("g")
+    expect(interval(eFlat, MAJOR, TENTH).notation).toBe("g")
   })
   it("returns A double sharp as G sharp's augmented second", () => {
     const gSharp = roots[ROOTS.G_SHARP]
-    expect(interval(gSharp, "aug", 2).notation).toBe("^^A")
+    expect(interval(gSharp, AUGMENTED, SECOND).notation).toBe("^^A")
   })
   it("returns A flat as G's minor second", () => {
     const g = roots[ROOTS.G]
-    expect(interval(g, "min", 2).notation).toBe("_A")
+    expect(interval(g, MINOR, SECOND).notation).toBe("_A")
   })
   it("returns C as B flat's major ninth", () => {
     const bFlat = roots[ROOTS.B_FLAT]
-    expect(interval(bFlat, "maj", 9).notation).toBe("c'")
+    expect(interval(bFlat, MAJOR, NINTH).notation).toBe("c'")
   })
   it("returns D as D's unison", () => {
     const d = roots[ROOTS.D]
-    expect(interval(d, "perf", 1).notation).toBe("D")
+    expect(interval(d, PERFECT, UNISON).notation).toBe("D")
   })
   it("returns B sharp as B's augmented octave", () => {
     const b = roots[ROOTS.B]
-    expect(interval(b, "aug", 8).notation).toBe("^b")
+    expect(interval(b, AUGMENTED, OCTAVE).notation).toBe("^b")
   })
   it("returns E flat as E's diminished octave", () => {
     const e = roots[ROOTS.E]
-    expect(interval(e, "dim", 8).notation).toBe("_e")
+    expect(interval(e, DIMINISHED, OCTAVE).notation).toBe("_e")
   })
 })
 

--- a/src/util/music/__tests__/scales.test.js
+++ b/src/util/music/__tests__/scales.test.js
@@ -1,6 +1,6 @@
 import { interval } from "../intervals"
 import { roots, ROOTS } from "../roots"
-import { scales, modes } from "../scales"
+import { scales, modes, SCALES, MODES } from "../scales"
 
 /*
   These are in no way a comprehensive collection of scales;
@@ -10,78 +10,78 @@ import { scales, modes } from "../scales"
 describe("Scale.notation()", () => {
   it("returns correct A flat major scale", () => {
     const aFlat = roots[ROOTS.A_FLAT]
-    const majorScale = scales[0]
+    const majorScale = scales[SCALES.MAJOR]
     expect(majorScale.notation(aFlat)).toBe("L:1/4\n_A_Bc_d_efg_a")
   })
   it("returns correct A sharp major scale", () => {
     const aSharp = roots[ROOTS.A_SHARP]
-    const majorScale = scales[0]
+    const majorScale = scales[SCALES.MAJOR]
     expect(majorScale.notation(aSharp)).toBe("L:1/4\n^A^B^^c^d^e^^f^^g^a")
   })
   it("returns correct F sharp natural minor scale", () => {
     const fSharp = roots[ROOTS.F_SHARP]
-    const naturalMinorScale = scales[1]
+    const naturalMinorScale = scales[SCALES.NATURAL_MINOR]
     expect(naturalMinorScale.notation(fSharp)).toBe("L:1/4\n^F^GAB^cde^f")
   })
   it("returns correct B harmonic minor scale", () => {
     const b = roots[ROOTS.B]
-    const harmonicMinorScale = scales[2]
+    const harmonicMinorScale = scales[SCALES.HARMONIC_MINOR]
     expect(harmonicMinorScale.notation(b)).toBe("L:1/4\nB^cde^fg^ab")
   })
   it("returns correct D sharp melodic minor scale", () => {
     const dSharp = roots[ROOTS.D_SHARP]
-    const melodicMinorScale = scales[3]
+    const melodicMinorScale = scales[SCALES.MELODIC_MINOR]
     expect(melodicMinorScale.notation(dSharp)).toBe("L:1/4\n^D^E^F^G^A^B^^c^d")
   })
   it("returns correct A sharp melodic minor scale", () => {
     const aSharp = roots[ROOTS.A_SHARP]
-    const melodicMinorScale = scales[3]
+    const melodicMinorScale = scales[SCALES.MELODIC_MINOR]
     expect(melodicMinorScale.notation(aSharp)).toBe("L:1/4\n^A^B^c^d^e^^f^^g^a")
   })
   it("returns correct A flat melodic minor scale", () => {
     const aFlat = roots[ROOTS.A_FLAT]
-    const melodicMinorScale = scales[3]
+    const melodicMinorScale = scales[SCALES.MELODIC_MINOR]
     expect(melodicMinorScale.notation(aFlat)).toBe("L:1/4\n_A_B_c_d_efg_a")
   })
   it("returns correct G sharp melodic minor scale", () => {
     const gSharp = roots[ROOTS.G_SHARP]
-    const melodicMinorScale = scales[3]
+    const melodicMinorScale = scales[SCALES.MELODIC_MINOR]
     expect(melodicMinorScale.notation(gSharp)).toBe("L:1/4\n^G^AB^c^d^e^^f^g")
   })
 
   it("returns correct E Ionian mode", () => {
     const e = roots[ROOTS.E]
-    const ionianMode = modes[0]
+    const ionianMode = modes[MODES.IONIAN]
     expect(ionianMode.notation(e)).toBe("L:1/4\nE^F^GAB^c^de")
   })
   it("returns correct F Dorian mode", () => {
     const f = roots[ROOTS.F]
-    const dorianMode = modes[1]
+    const dorianMode = modes[MODES.DORIAN]
     expect(dorianMode.notation(f)).toBe("L:1/4\nFG_A_Bcd_ef")
   })
   it("returns correct B flat Phrygian mode", () => {
     const bFlat = roots[ROOTS.B_FLAT]
-    const phrygianMode = modes[2]
+    const phrygianMode = modes[MODES.PHRYGIAN]
     expect(phrygianMode.notation(bFlat)).toBe("L:1/4\n_B_c_d_ef_g_a_b")
   })
   it("returns correct D flat Lydian mode", () => {
     const dFlat = roots[ROOTS.D_FLAT]
-    const lydianMode = modes[3]
+    const lydianMode = modes[MODES.LYDIAN]
     expect(lydianMode.notation(dFlat)).toBe("L:1/4\n_D_EFG_A_Bc_d")
   })
   it("returns correct G sharp Mixolydian mode", () => {
     const gSharp = roots[ROOTS.G_SHARP]
-    const mixolydianMode = modes[4]
+    const mixolydianMode = modes[MODES.MIXOLYDIAN]
     expect(mixolydianMode.notation(gSharp)).toBe("L:1/4\n^G^A^B^c^d^e^f^g")
   })
   it("returns correct E flat Aeolian mode", () => {
     const eFlat = roots[ROOTS.E_FLAT]
-    const aeolianMode = modes[5]
+    const aeolianMode = modes[MODES.AEOLIAN]
     expect(aeolianMode.notation(eFlat)).toBe("L:1/4\n_EF_G_A_B_c_d_e")
   })
   it("returns correct E Locrian mode", () => {
     const a = roots[ROOTS.A]
-    const locrianMode = modes[6]
+    const locrianMode = modes[MODES.LOCRIAN]
     expect(locrianMode.notation(a)).toBe("L:1/4\nA_Bcd_efga")
   })
 })

--- a/src/util/music/intervals.js
+++ b/src/util/music/intervals.js
@@ -37,7 +37,13 @@ export const UNISON = 1,
   FIFTH = 5,
   SIXTH = 6,
   SEVENTH = 7,
-  OCTAVE = 8
+  OCTAVE = 8,
+  NINTH = 9,
+  TENTH = 10,
+  ELEVENTH = 11,
+  TWELFTH = 12,
+  THIRTEENTH = 13,
+  FOURTEENTH = 14
 
 export const intervalLabels = [
   "Priimi",

--- a/src/util/music/scales.js
+++ b/src/util/music/scales.js
@@ -38,6 +38,13 @@ class Scale {
   }
 }
 
+export const SCALES = {
+  MAJOR: 0,
+  NATURAL_MINOR: 1,
+  HARMONIC_MINOR: 2,
+  MELODIC_MINOR: 3,
+}
+
 export const scales = [
   new Scale(
     "Duuri",
@@ -107,6 +114,16 @@ export const scales = [
       scale.split(" ")[1],
   ),
 ]
+
+export const MODES = {
+  IONIAN: 0,
+  DORIAN: 1,
+  PHRYGIAN: 2,
+  LYDIAN: 3,
+  MIXOLYDIAN: 4,
+  AEOLIAN: 5,
+  LOCRIAN: 6,
+}
 
 export const modes = [
   new Scale(

--- a/src/util/random.js
+++ b/src/util/random.js
@@ -1,12 +1,10 @@
-// from MDN; min is inclusive, max exclusive
-
 /**
- * Returns a random integer from the given range. Taken from MDN:
+ * Returns a random integer from the given range.
+ * Adapted from MDN:
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random#Getting_a_random_integer_between_two_values
  *
- * It returns the shuffled array (note that it is the original array, only the
- * elements have been shuffled).
- *
- * @param {*} array The array that will be shuffled in place
+ * @param {*} min The minimum value of the range (inclusive)
+ * @param {*} max The maximum value of the range (exclusive)
  */
 export const randomInt = (min, max) =>
   Math.floor(Math.random() * (max - min)) + min


### PR DESCRIPTION
Add enums to music utils tests.
The important thing is that the constant for qualities
(DIMINISHES, MINOR and so on) have been added to the tests,
so if one decides to change their values (which are now
strings, like "dim", "min" and so on), the tests will still
work without any further change.

Fix randomInt comment

Fix missing brackets.
The if block was originally without brackets because
it included only one statement, then another statement
was added, but the brackets were forgotten, so the second
statement was executed always.